### PR TITLE
Release Fix: Added BPM configuration.

### DIFF
--- a/jobs/acceptance-tests-brain/spec
+++ b/jobs/acceptance-tests-brain/spec
@@ -17,6 +17,7 @@ templates:
   run.erb: bin/run
   environment.sh.erb: bin/environment.sh
   pre-start.erb: bin/pre-start
+  bpm.yml.erb: config/bpm.yml
 
 properties:
   acceptance_tests_brain.domain:

--- a/jobs/acceptance-tests-brain/templates/bpm.yml.erb
+++ b/jobs/acceptance-tests-brain/templates/bpm.yml.erb
@@ -1,0 +1,4 @@
+processes:
+  - name: acceptance-tests-brain
+    executable: /var/vcap/jobs/acceptance-tests-brain/bin/run
+    ephemeral_disk: true


### PR DESCRIPTION
# Context

  - https://github.com/SUSE/kubecf/issues/31
  - https://jira.suse.com/browse/CAP-520

# Description

This PR is a bugfix.

The main job (`acceptance-tests-brain`) was without no BPM configuration.
Without such the operator cannot process the release/job.
The PR adds the missing configuration, deriving it from the configuration for the CATS.
