### PR TITLE
Release fix: Prestart assumptions about environment do not hold anymore in kubecf/operator.

### DIFF
--- a/jobs/acceptance-tests-brain/templates/pre-start.erb
+++ b/jobs/acceptance-tests-brain/templates/pre-start.erb
@@ -4,9 +4,10 @@ set -o errexit
 set -o nounset
 
 PATH=$PATH:/var/vcap/packages/cli/bin
-API="<%= properties.smoke_tests.api %>"
-PASSWORD="<%= properties.acceptance_tests_brain.password %>"
 
-cf api --skip-ssl-validation "${API}"
-cf auth admin "${PASSWORD}"
+cf api --skip-ssl-validation \
+   "https://<%= properties.smoke_tests.api.shellescape %>"
+cf auth \
+   "<%= properties.acceptance_tests_brain.user.shellescape %>" \
+   "<%= properties.acceptance_tests_brain.password.shellescape %>"
 cf enable-feature-flag diego_docker

--- a/jobs/acceptance-tests-brain/templates/pre-start.erb
+++ b/jobs/acceptance-tests-brain/templates/pre-start.erb
@@ -1,4 +1,5 @@
 #!/bin/sh
+<% require 'shellwords' %>
 
 set -o errexit
 set -o nounset
@@ -6,8 +7,10 @@ set -o nounset
 PATH=$PATH:/var/vcap/packages/cli/bin
 
 cf api --skip-ssl-validation \
-   "https://<%= properties.smoke_tests.api.shellescape %>"
+   https://<%= properties.smoke_tests.api.shellescape %>
+
 cf auth \
-   "<%= properties.acceptance_tests_brain.user.shellescape %>" \
-   "<%= properties.acceptance_tests_brain.password.shellescape %>"
+   <%= properties.acceptance_tests_brain.user.shellescape %> \
+   <%= properties.acceptance_tests_brain.password.shellescape %>
+
 cf enable-feature-flag diego_docker

--- a/jobs/acceptance-tests-brain/templates/pre-start.erb
+++ b/jobs/acceptance-tests-brain/templates/pre-start.erb
@@ -4,7 +4,9 @@ set -o errexit
 set -o nounset
 
 PATH=$PATH:/var/vcap/packages/cli/bin
+API="<%= properties.smoke_tests.api %>"
+PASSWORD="<%= properties.acceptance_tests_brain.password %>"
 
-cf api --skip-ssl-validation "https://api.$DOMAIN"
-cf auth admin "${CLUSTER_ADMIN_PASSWORD}"
+cf api --skip-ssl-validation "${API}"
+cf auth admin "${PASSWORD}"
 cf enable-feature-flag diego_docker

--- a/jobs/acceptance-tests-brain/templates/run.erb
+++ b/jobs/acceptance-tests-brain/templates/run.erb
@@ -22,6 +22,7 @@ if [ ! -f "${HELM_BIN_DIR}/${HELM_VERSION}/helm" ]; then
 fi
 
 export PATH="${HELM_BIN_DIR}/${HELM_VERSION}:${PATH}"
+export PATH="/var/vcap/packages/ruby-2.3/bin:${PATH}"
 export PATH="/var/vcap/packages/cli/bin:${PATH}"
 export PATH="/var/vcap/packages/kubectl/bin:${PATH}"
 export PATH="/var/vcap/packages/credhub-cli/bin:${PATH}"

--- a/packages/acceptance-tests-brain/spec
+++ b/packages/acceptance-tests-brain/spec
@@ -4,6 +4,7 @@ dependencies:
   - cli
   - kubectl
   - golang1.10
+  - ruby-2.3
 files:
   - acceptance-tests-brain/test-scripts/*
   - acceptance-tests-brain/test-resources/**/*


### PR DESCRIPTION
Ref:
  - https://jira.suse.com/browse/CAP-520
  - https://github.com/SUSE/kubecf/issues/31

Define the unbound variables with proper ERB substitutions referencing job properties.
