### PR TITLE
Disabled the minibroker tests.

### DIFF
--- a/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
@@ -1,5 +1,13 @@
 #!/usr/bin/env ruby
 
+require_relative 'testutils'
+
+puts "Minibroker #{c_bold}Test disabled#{c_reset}."
+puts "Have to set #{c_bold}KUBERNETES_REPO#{c_reset} dynamically per kube version."
+puts "Have to export this variable as spec which can be set from the chart, and templated."
+puts "#{c_bold}Cannot pass#{c_reset} on all platforms before that is done.'"
+exit_skipping_test
+
 require_relative 'minibroker_helper'
 
 tester = MiniBrokerTest.new('redis', '6379')

--- a/src/acceptance-tests-brain/test-scripts/014_minibroker_mariadb_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/014_minibroker_mariadb_test.rb
@@ -1,5 +1,13 @@
 #!/usr/bin/env ruby
 
+require_relative 'testutils'
+
+puts "Minibroker #{c_bold}Test disabled#{c_reset}."
+puts "Have to set #{c_bold}KUBERNETES_REPO#{c_reset} dynamically per kube version."
+puts "Have to export this variable as spec which can be set from the chart, and templated."
+puts "#{c_bold}Cannot pass#{c_reset} on all platforms before that is done.'"
+exit_skipping_test
+
 require_relative 'minibroker_helper'
 
 $DB_NAME = random_suffix('db')

--- a/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
@@ -1,5 +1,13 @@
 #!/usr/bin/env ruby
 
+require_relative 'testutils'
+
+puts "Minibroker #{c_bold}Test disabled#{c_reset}."
+puts "Have to set #{c_bold}KUBERNETES_REPO#{c_reset} dynamically per kube version."
+puts "Have to export this variable as spec which can be set from the chart, and templated."
+puts "#{c_bold}Cannot pass#{c_reset} on all platforms before that is done.'"
+exit_skipping_test
+
 require_relative 'minibroker_helper'
 
 $DB_NAME = random_suffix('db')

--- a/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
@@ -1,5 +1,13 @@
 #!/usr/bin/env ruby
 
+require_relative 'testutils'
+
+puts "Minibroker #{c_bold}Test disabled#{c_reset}."
+puts "Have to set #{c_bold}KUBERNETES_REPO#{c_reset} dynamically per kube version."
+puts "Have to export this variable as spec which can be set from the chart, and templated."
+puts "#{c_bold}Cannot pass#{c_reset} on all platforms before that is done.'"
+exit_skipping_test
+
 require_relative 'minibroker_helper'
 
 tester = MiniBrokerTest.new('mongodb', '27017')


### PR DESCRIPTION
Ref: https://jira.suse.com/browse/CAP-526

Until we have them semi-auto-adapting to the different kube versions of the supported platforms.

Tested on a local cluster that this properly skips the minibroker tests.