### PR TITLE
Properly quote the pattern lists.

### DIFF
--- a/jobs/acceptance-tests-brain/templates/bpm.yml.erb
+++ b/jobs/acceptance-tests-brain/templates/bpm.yml.erb
@@ -3,7 +3,7 @@ processes:
     executable: /var/vcap/jobs/acceptance-tests-brain/bin/run
     ephemeral_disk: true
     env:
-      EXCLUDE: <%= p('acceptance_tests_brain.exclude') %>
+      EXCLUDE: '<%= p('acceptance_tests_brain.exclude') %>'
       IN_ORDER: <%= p('acceptance_tests_brain.in_order') %>
-      INCLUDE: <%= p('acceptance_tests_brain.include') %>
+      INCLUDE: '<%= p('acceptance_tests_brain.include') %>'
       VERBOSE: <%= p('acceptance_tests_brain.verbose') %>


### PR DESCRIPTION
Ref https://jira.suse.com/browse/CAP-1353

See also https://github.com/SUSE/catapult/pull/160 and https://github.com/SUSE/cap/pull/4

Not quoting the pattern lists will cause the yaml processor to misidentify a pattern like `010` as a number, an octal number to be specific, and then write it back as decimal, i.e. `8`.
The quotes force interpretation as string, preventing any rewrite.

Testing: Manually on a minikube, using a locally generated brain test release, and running the brain tests with the include pattern above, and verified that it reaches the runner command line unchanged.