### PR TITLE
Attempt to fix issues with insecure-registry test

### DIFF
--- a/src/acceptance-tests-brain/test-resources/docker-uploader/manifest.yml
+++ b/src/acceptance-tests-brain/test-resources/docker-uploader/manifest.yml
@@ -21,7 +21,7 @@ applications:
     mkdir certs
     &&
     openssl req -newkey rsa:4096 -nodes -sha256  -x509 -days 365
-    -subj /CN=insecure-registry.((tcp-domain))
+    -subj /CN=((tcp-domain))
     -keyout certs/domain.key -out certs/domain.crt
     &&
     ./bin/registry serve ./config.yml

--- a/src/acceptance-tests-brain/test-scripts/010_insecure_registry_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/010_insecure_registry_test.rb
@@ -33,7 +33,7 @@ Timeout::timeout(ENV.fetch('TESTBRAIN_TIMEOUT', '600').to_i - 60) do
   # See ticket https://github.com/cloudfoundry-incubator/kubecf/issues/466
   # Also see   https://github.com/cloudfoundry-incubator/kubecf/issues/424
   REGISTRIES = {
-    'insecure-registry' => "https://insecure-registry.#{CF_TCP_DOMAIN}:20005"     # Self-signed SSL cert
+    'insecure-registry' => "https://#{CF_TCP_DOMAIN}:20005"     # Self-signed SSL cert
   }
 
   at_exit do
@@ -69,9 +69,10 @@ Timeout::timeout(ENV.fetch('TESTBRAIN_TIMEOUT', '600').to_i - 60) do
   at_exit do
     set errexit: false do
       puts "........................................................................... SHUTDOWN"
-      run "cf delete -f secure-registry"
-      run "cf delete -f insecure-registry"
-      run "cf delete -f uploader"
+      %w(secure-registry insecure-registry uploader).each do |app|
+        run "cf logs --recent #{app}"
+        run "cf delete -f #{app}"
+      end
     end
   end
   run "cf push -f manifest.yml --var tcp-domain=#{CF_TCP_DOMAIN}",


### PR DESCRIPTION
- Drop the app host name on the TCP route; that's not always configured correctly in deployments.
  - This requires a matching kubecf change.
- Drop the threading-based logging; we appear to be hitting time out issues with the threads not terminating correctly.