### PR TITLE
fix: accept beta storage class annotations

### DIFF
--- a/src/acceptance-tests-brain/test-scripts/000_cflogin_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/000_cflogin_test.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['CFLOGIN_ENABLED'] != 'true'
-
 require_relative 'testutils'
+
+exit_skipping_test if ENV['CFLOGIN_ENABLED'] != 'true'
 
 login
 setup_org_space

--- a/src/acceptance-tests-brain/test-scripts/001_pushapp_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/001_pushapp_test.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['PUSHAPP_ENABLED'] != 'true'
-
 require_relative 'testutils'
+
+exit_skipping_test if ENV['PUSHAPP_ENABLED'] != 'true'
 
 login
 setup_org_space

--- a/src/acceptance-tests-brain/test-scripts/002_securitygroups_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/002_securitygroups_test.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['SECURITYGROUPS_ENABLED'] != 'true'
-
 require_relative 'testutils'
+
+exit_skipping_test if ENV['SECURITYGROUPS_ENABLED'] != 'true'
 
 login
 setup_org_space

--- a/src/acceptance-tests-brain/test-scripts/003_dockerapp_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/003_dockerapp_test.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['DOCKERAPP_ENABLED'] != 'true'
-
 require_relative 'testutils'
+
+exit_skipping_test if ENV['DOCKERAPP_ENABLED'] != 'true'
 
 login
 setup_org_space

--- a/src/acceptance-tests-brain/test-scripts/004_tcprouting_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/004_tcprouting_test.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['TCPROUTING_ENABLED'] != 'true'
-
 require_relative 'testutils'
+
+exit_skipping_test if ENV['TCPROUTING_ENABLED'] != 'true'
 
 login
 setup_org_space

--- a/src/acceptance-tests-brain/test-scripts/005_metron_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/005_metron_test.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['METRON_ENABLED'] != 'true'
-
 require_relative 'testutils'
+
+exit_skipping_test if ENV['METRON_ENABLED'] != 'true'
 
 login
 setup_org_space

--- a/src/acceptance-tests-brain/test-scripts/006_ssh_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/006_ssh_test.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['SSH_ENABLED'] != 'true'
-
 require_relative 'testutils'
+
+exit_skipping_test if ENV['SSH_ENABLED'] != 'true'
 
 login
 setup_org_space

--- a/src/acceptance-tests-brain/test-scripts/007_buildpacks_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/007_buildpacks_test.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['BUILDPACKS_ENABLED'] != 'true'
+require 'json'
 
 require_relative 'testutils'
 
-require 'json'
+exit_skipping_test if ENV['BUILDPACKS_ENABLED'] != 'true'
 
 login
 setup_org_space

--- a/src/acceptance-tests-brain/test-scripts/009_backup_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/009_backup_test.rb
@@ -1,9 +1,10 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['BACKUP_ENABLED'] != 'true'
+require 'json'
 
 require_relative 'testutils'
-require 'json'
+
+exit_skipping_test if ENV['BACKUP_ENABLED'] != 'true'
 
 login
 setup_org_space

--- a/src/acceptance-tests-brain/test-scripts/010_insecure_registry_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/010_insecure_registry_test.rb
@@ -1,10 +1,11 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['INSECURE_REGISTRY_ENABLED'] != 'true'
-
-require_relative 'testutils'
 require 'fileutils'
 require 'json'
+
+require_relative 'testutils'
+
+exit_skipping_test if ENV['INSECURE_REGISTRY_ENABLED'] != 'true'
 
 Timeout::timeout(ENV.fetch('TESTBRAIN_TIMEOUT', '600').to_i - 60) do
   # the timeout stuff isn't necessary, it just gives it time to clean up

--- a/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.rb
@@ -4,11 +4,12 @@
 # This tests assumes that the kernel modules `nfs` and `nfsd` are
 # already loaded.
 
-exit_skipping_test if ENV['NFSPERSI_ENABLED'] != 'true'
-
-require_relative 'testutils'
 require 'json'
 require 'yaml'
+
+require_relative 'testutils'
+
+exit_skipping_test if ENV['NFSPERSI_ENABLED'] != 'true'
 
 use_global_timeout
 

--- a/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['MINIBROKER_REDIS_ENABLED'] != 'true'
-
 require_relative 'testutils'
 require_relative 'minibroker_helper'
+
+exit_skipping_test if ENV['MINIBROKER_REDIS_ENABLED'] != 'true'
 
 tester = MiniBrokerTest.new('redis', '6379')
 tester.service_params = {

--- a/src/acceptance-tests-brain/test-scripts/013_credhub_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/013_credhub_test.rb
@@ -1,14 +1,14 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['CREDHUB_ENABLED'] != 'true'
-
-# Skip the test if we do not have credhub auth set up
-exit_skipping_test unless ENV['CREDHUB_CLIENT'] && ENV['CREDHUB_SECRET']
-
 require 'base64'
 require 'json'
 
 require_relative 'testutils'
+
+exit_skipping_test if ENV['CREDHUB_ENABLED'] != 'true'
+
+# Skip the test if we do not have credhub auth set up
+exit_skipping_test unless ENV['CREDHUB_CLIENT'] && ENV['CREDHUB_SECRET']
 
 CH_CLI = 'credhub'
 CH_SERVICE = "https://credhub.#{ENV['CF_DOMAIN']}"

--- a/src/acceptance-tests-brain/test-scripts/014_minibroker_mariadb_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/014_minibroker_mariadb_test.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['MINIBROKER_MARIADB_ENABLED'] != 'true'
-
 require_relative 'testutils'
 require_relative 'minibroker_helper'
+
+exit_skipping_test if ENV['MINIBROKER_MARIADB_ENABLED'] != 'true'
 
 $DB_NAME = random_suffix('db')
 

--- a/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['MINIBROKER_POSTGRES_ENABLED'] != 'true'
-
 require_relative 'testutils'
 require_relative 'minibroker_helper'
+
+exit_skipping_test if ENV['MINIBROKER_POSTGRES_ENABLED'] != 'true'
 
 $DB_NAME = random_suffix('db')
 

--- a/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['MINIBROKER_MONGODB_ENABLED'] != 'true'
-
 require_relative 'testutils'
 require_relative 'minibroker_helper'
+
+exit_skipping_test if ENV['MINIBROKER_MONGODB_ENABLED'] != 'true'
 
 tester = MiniBrokerTest.new('mongodb', '27017')
 tester.service_params = {

--- a/src/acceptance-tests-brain/test-scripts/017_syslog_forwarding_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/017_syslog_forwarding_test.rb
@@ -27,12 +27,13 @@
 #
 #    See (C).
 
-exit_skipping_test if ENV['SYSLOG_FORWARDING_ENABLED'] != 'true'
-
-require_relative 'testutils'
 require 'json'
 require 'securerandom'
 require 'timeout'
+
+require_relative 'testutils'
+
+exit_skipping_test if ENV['SYSLOG_FORWARDING_ENABLED'] != 'true'
 
 def show_env
     ENV.sort.select { |k, v| k.start_with? 'KUBECF_LOG_' }.each do |k, v|

--- a/src/acceptance-tests-brain/test-scripts/018_autoscaler_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/018_autoscaler_test.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
-exit_skipping_test if ENV['AUTOSCALER_ENABLED'] != 'true'
-
 require_relative 'testutils'
+
+exit_skipping_test if ENV['AUTOSCALER_ENABLED'] != 'true'
 
 # Origin of the various pieces of configuration.
 ##

--- a/src/acceptance-tests-brain/test-scripts/testutils.rb
+++ b/src/acceptance-tests-brain/test-scripts/testutils.rb
@@ -21,9 +21,14 @@ def storage_class
     return $storage_class if $storage_class && !$storage_class.empty?
     storage_classes = JSON.parse(capture('kubectl get storageclass --output=json'))
     default_storage_class = storage_classes['items'].find do |storage_class|
-        storage_class.fetch('metadata', {})
-            .fetch('annotations', {})
-            .fetch('storageclass.kubernetes.io/is-default-class', 'false') == 'true'
+        metadata = storage_class['metadata'] || {}
+        annotations = metadata['annotations'] || {}
+        %w(
+            storageclass.kubernetes.io/is-default-class
+            storageclass.beta.kubernetes.io/is-default-class
+        ).any? do |key|
+            annotations[key] == 'true'
+        end
     end
     $storage_class = default_storage_class['metadata']['name'] || 'persistent'
 end


### PR DESCRIPTION
The Kubernetes clusters we create on AKS by default uses an old enough version that the default storage class is flagged with the beta annotation.  Try to allow either that or the release one.