### PR TITLE
fix: tweak pattern for metron logs, to work for both diego and eirini.

### DIFF
--- a/src/acceptance-tests-brain/test-scripts/005_metron_test.rb
+++ b/src/acceptance-tests-brain/test-scripts/005_metron_test.rb
@@ -17,4 +17,4 @@ end
 run "cf push #{app_name} -p #{resource_path('node-env')}"
 
 # test if there are logs
-run "cf logs #{app_name} --recent | grep -i Downloading"
+run "cf logs #{app_name} --recent | grep -i 'Creating build for app'"


### PR DESCRIPTION
See cloudfoundry-incubator/kubecf/issues/1371

The current commit fixes the breakage of test case 005 metron. The pattern check for in the test was diego-specific, breaking the test on eirini. The new pattern exists in both configurations.

Tests 004 and 010 look to be issues with TCP routing under eirini.


